### PR TITLE
BBcode html escape

### DIFF
--- a/src/bbcode/constructor.rs
+++ b/src/bbcode/constructor.rs
@@ -52,14 +52,14 @@ impl Constructor {
                     if render {
                         contents.push_str(&self.build(child))
                     } else {
-                        contents.push_str(child.borrow().get_raw());
+                        contents.push_str(Self::sanitize(child.borrow().get_raw()));
                     }
                 }
             }
             // No, so our contents must be handled literally.
             else {
                 for child in node.children() {
-                    contents.push_str(child.borrow().get_raw());
+                    contents.push_str(Self::sanitize(child.borrow().get_raw()));
                 }
             }
 

--- a/src/bbcode/tokenize.rs
+++ b/src/bbcode/tokenize.rs
@@ -106,7 +106,7 @@ fn parse_url(input: &str) -> IResult<&str, Token> {
 }
 
 fn tag_and_argument(input: &str) -> IResult<&str, &str> {
-    recognize(many1(none_of("\r\n[]")))(input)
+    recognize(many1(none_of("\r\n[]<>")))(input)
 }
 
 fn token_from_argument(input: &str) -> IResult<&str, (&str, (&str, Option<&str>))> {


### PR DESCRIPTION
Escapes content in bbcode tags, and stops parsing of tags containing '<' and '>'.

Probably not all encompassing, but stops exploits demonstrated by `@cohle@shitposter.club`, https://poa.st/@cohle@shitposter.club/posts/ANj4rCNgQKCoyvVHfs