### PR TITLE
Fix arbitrary file read bug in view_public_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-next"
-version = "5.0.3"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585e5eaf57eceaa199ba6f6a1f46bdad7992930bb7b45b40275d9445b5ba2bc8"
+checksum = "a80971eee67be0079a1c8890bde68226fe9bd0441740fd6ddd0cee131486b321"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-next",
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sys-next"
-version = "5.0.1"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba12dea33516e30c160ce557c7e43dd857276368eb1cd0eef4fce6529f2dee5"
+checksum = "d780b36e092254367e2f1f21191992735c8e23f31a5a5a8678db3a79f775021f"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ derive_more = "^0"
 dissimilar = "^1"
 dotenv = "0.15.0"
 env_logger = "0.9.0"
-ffmpeg-next = "^5"
+ffmpeg-next = "^5.0.4"
 futures = { version = "0.3.19", default-features = false }
 futures-util = { version = "0.3.19", default-features = false }
 google-authenticator = { version = "0.3.0", features = ["with-qrcode"] }

--- a/src/web/asset.rs
+++ b/src/web/asset.rs
@@ -89,7 +89,7 @@ async fn view_file_by_hash(req: HttpRequest) -> impl Responder {
 async fn view_public_file(req: HttpRequest) -> Result<fs::NamedFile, Error> {
     let mut path: PathBuf = PathBuf::from("public/assets/");
     let req_path: PathBuf = req.match_info().query("filename").parse().unwrap();
-    path.push(req_path);
+    path.push(req_path.file_name().unwrap());
 
     let file = fs::NamedFile::open(path)?;
 


### PR DESCRIPTION
A bug was found in the `view_public_file` function in `src/web/asset.rs`, that allows an adversary to read an arbitrary file from the web server. The following curl command will read the .env file:
```sh
curl 'http://127.0.0.1:8080/public/assets/%2e%2e/%2e%2e/.env'
```

These changes solve the issue by taking only the file name from `req_path` when building the `path` that gets read from the file system, discarding any path traversal preceding the file name.