### PR TITLE
Use the type system to improve sanitization while generating HTML for bbcode

### DIFF
--- a/src/bbcode/element.rs
+++ b/src/bbcode/element.rs
@@ -1,4 +1,4 @@
-use super::{Tag, Token};
+use super::{SafeHtml, Tag, Token};
 
 #[derive(Debug, Clone)]
 pub enum ElementDisplay {
@@ -241,8 +241,8 @@ impl<'str> Element<'str> {
     }
 
     /// Unwinds element into an opening tag string.
-    pub fn to_open_str(&self) -> String {
-        self.raw.unwrap_or("").to_owned()
+    pub fn to_open_str(&self) -> SafeHtml {
+        SafeHtml::sanitize(self.raw.unwrap_or(""))
 
         //match &self.tag {
         //    Some(tag) => match &self.argument {
@@ -257,17 +257,18 @@ impl<'str> Element<'str> {
     }
 
     /// Unwinds element into an closing tag string.
-    pub fn to_close_str(&self) -> String {
+    pub fn to_close_str(&self) -> SafeHtml {
         // Only explicitly closed tags reverse to BbCode
         if self.is_explicit() {
-            match &self.tag {
+            let result = match &self.tag {
                 Some(tag) => format!("[/{}]", tag),
                 None => "[/]".to_string(),
-            }
+            };
+            SafeHtml::sanitize(result.as_str())
         }
         // Broken, implicitly closed tags reverse to nothing.
         else {
-            String::new()
+            SafeHtml::new()
         }
     }
 }

--- a/src/bbcode/sanitation.rs
+++ b/src/bbcode/sanitation.rs
@@ -1,0 +1,181 @@
+use super::Smilies;
+use std::collections::HashMap;
+use std::ops;
+
+/// Sanitizes a char for HTML.
+pub fn sanitize(input: &str) -> String {
+    // Some insane person did an extremely detailed benchmark of this.
+    // https://lise-henry.github.io/articles/optimising_strings.html
+    let len = input.len();
+    let mut output: Vec<u8> = Vec::with_capacity(len * 4);
+
+    for c in input.bytes() {
+        // https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+        match c {
+            b'<' => output.extend_from_slice(b"&lt;"),
+            b'>' => output.extend_from_slice(b"&gt;"),
+            b'&' => output.extend_from_slice(b"&amp;"),
+            b'\"' => output.extend_from_slice(b"&quot;"),
+            b'\'' => output.extend_from_slice(b"&#x27;"),
+            _ => output.push(c),
+        }
+    }
+
+    unsafe { String::from_utf8_unchecked(output) }
+}
+
+/// Use the type system to help avoid XSS/script injection vulnerabilities. A SafeHtml string can
+/// only be constructed from:
+///  - a string which has been sanitized (i.e. <>&"' characters replaced with HTML entities)
+///  - a literal string, enforced by the 'static lifetime annotation
+///  - concatenations of already constructed SafeHtml strings
+/// A SafeHtml string cannot be constructed from unsanitized user input, and this is enforced by
+/// the type system. However, this does not guarantee safety against injection. You could
+/// specify "<script>" as a string literal and it would be considered safe. But it is easier to
+/// audit the string literals than to audit every string operation.
+#[derive(Debug)]
+pub struct SafeHtml(String);
+
+impl SafeHtml {
+    /// Return an empty SafeHtml string
+    pub fn new() -> Self {
+        Self(String::new())
+    }
+
+    /// Return an empty SafeHtml string with the given capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(String::with_capacity(capacity))
+    }
+
+    /// Take a literal string and treat it as "safe" HTML. It is up to the user to make sure that
+    /// it is truly safe.
+    pub fn from_literal(trusted: &'static str) -> Self {
+        Self(String::from(trusted))
+    }
+
+    /// Return a SafeHtml string with HTML characters escaped
+    pub fn sanitize(input: &str) -> Self {
+        Self(sanitize(input))
+    }
+
+    /// Return a SafeHtml string with HTML characters escaped and emojis replaced. The emoji replacement
+    /// strings are implicitly considered safe (future TODO). It is important that sanitization and
+    /// replacement are done as one step, because replacing them on arbitrary SafeHtml strings could cause
+    /// them to become unsafe.
+    pub fn sanitize_and_replace_smilies(input: &str, smilies: &Smilies) -> Self {
+        let mut result = sanitize(input);
+        let mut hits: u8 = 0;
+        let mut hit_map: HashMap<u8, &String> = HashMap::with_capacity(smilies.count());
+
+        for (code, replace_with) in smilies.iter() {
+            if result.contains(code) {
+                hit_map.insert(hits, replace_with);
+                result = result.replace(code, &format!("\r{}", hits));
+                hits += 1;
+            }
+        }
+
+        for (hit, replace_with) in hit_map {
+            result = result.replace(&format!("\r{}", hit), replace_with);
+        }
+
+        Self(result)
+    }
+
+    /// Concatenate self with the given SafeHtml string
+    pub fn push(&mut self, string: &Self) {
+        self.0.push_str(&string.0)
+    }
+
+    /// Concatenate self with the given literal string
+    pub fn push_literal(&mut self, string: &'static str) {
+        self.0.push_str(&string)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn take(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for SafeHtml {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl ops::Add<&SafeHtml> for SafeHtml {
+    type Output = SafeHtml;
+
+    fn add(mut self, rhs: &SafeHtml) -> SafeHtml {
+        self.push(rhs);
+        self
+    }
+}
+
+impl ops::Add<&'static str> for SafeHtml {
+    type Output = SafeHtml;
+
+    fn add(mut self, rhs: &'static str) -> SafeHtml {
+        self.push_literal(rhs);
+        self
+    }
+}
+
+mod tests {
+    use super::super::Smilies;
+    use super::SafeHtml;
+
+    #[test]
+    fn basic() {
+        assert_eq!("", SafeHtml::new().as_ref());
+        assert_eq!("", SafeHtml::with_capacity(100).as_ref());
+        assert_eq!("<>&\'\"", SafeHtml::from_literal("<>&\'\"").as_ref());
+    }
+
+    #[test]
+    fn escaped() {
+        assert_eq!(
+            "&lt;&gt;&amp;&#x27;&quot;",
+            SafeHtml::sanitize("<>&\'\"").as_ref()
+        );
+    }
+
+    #[test]
+    fn concatenation() {
+        let result = SafeHtml::from_literal("a<bc") + "xy<z" + "_<";
+        assert_eq!("a<bcxy<z_<", result.as_ref());
+
+        let user_input = SafeHtml::sanitize("x < y");
+        let result = SafeHtml::from_literal("<b>") + &user_input + "</b>";
+        assert_eq!("<b>x &lt; y</b>", result.as_ref());
+
+        let mut result = SafeHtml::with_capacity(256);
+        result = result + "<b>" + &user_input + "</b>";
+        assert_eq!("<b>x &lt; y</b>", result.as_ref());
+    }
+
+    #[test]
+    fn smilies_replacement() {
+        let smilies = Smilies::new_from_tuples(vec![
+            (":)".to_owned(), "&#x1F600;".to_owned()),
+            (":mad:".to_owned(), "&#x1F620;".to_owned()),
+            (":test:".to_owned(), "<test x=\"blah\" />".to_owned()),
+        ]);
+        assert_eq!(
+            "&#x1F620;&#x1F600;",
+            SafeHtml::sanitize_and_replace_smilies(":mad::)", &smilies).as_ref()
+        );
+        assert_eq!(
+            "&lt;&amp;my&gt; &#x1F600;&quot;",
+            SafeHtml::sanitize_and_replace_smilies("<&my> :)\"", &smilies).as_ref()
+        );
+        assert_eq!(
+            "&lt;<test x=\"blah\" />&gt;",
+            SafeHtml::sanitize_and_replace_smilies("<:test:>", &smilies).as_ref()
+        );
+    }
+}

--- a/src/bbcode/tag/embed.rs
+++ b/src/bbcode/tag/embed.rs
@@ -1,37 +1,39 @@
-use super::Element;
+use super::{Element, SafeHtml};
 use std::cell::RefMut;
 use url::Url;
 
 impl super::Tag {
-    pub fn open_img_tag(_: RefMut<Element>) -> String {
-        String::new()
+    pub fn open_img_tag(_: RefMut<Element>) -> SafeHtml {
+        SafeHtml::new()
     }
 
-    pub fn fill_img_tag(mut el: RefMut<Element>, contents: String) -> String {
+    pub fn fill_img_tag(mut el: RefMut<Element>, contents: &str) -> SafeHtml {
         // Our URL comes from inside the tag.
-        if let Ok(url) = Url::parse(&contents) {
+        if let Ok(url) = Url::parse(contents) {
             match url.scheme() {
                 "http" | "https" => {
                     el.clear_contents();
-                    return format!("<img src=\"{}\" />", url.as_str());
+                    let sanitized_url = SafeHtml::sanitize(url.as_str());
+                    let empty = SafeHtml::with_capacity(sanitized_url.len() + 32);
+                    return empty + "<img src=\"" + &sanitized_url + "\" />";
                 }
                 _ => {}
             }
         }
 
         el.set_broken();
-        contents
+        SafeHtml::sanitize(contents)
     }
 
-    pub fn open_url_tag(el: RefMut<Element>) -> String {
+    pub fn open_url_tag(el: RefMut<Element>) -> SafeHtml {
         if el.is_broken() {
             el.to_open_str()
         } else {
-            String::new()
+            SafeHtml::new()
         }
     }
 
-    pub fn fill_url_tag(mut el: RefMut<Element>, contents: String) -> String {
+    pub fn fill_url_tag(mut el: RefMut<Element>, contents: &str, sanitized: SafeHtml) -> SafeHtml {
         let mut url: Option<Url> = None;
 
         if let Some(arg) = el.get_argument() {
@@ -39,28 +41,32 @@ impl super::Tag {
                 Ok(url) => url,
                 Err(_) => {
                     el.set_broken();
-                    return contents;
+                    return sanitized;
                 }
             }
             // TODO: Check for unfurl="true/false"
         }
 
         if url.is_none() {
-            if let Ok(curl) = Url::parse(&contents) {
+            if let Ok(curl) = Url::parse(contents) {
                 url = Some(curl)
             }
         }
 
         match url {
-            Some(url) => format!(
-                "<a class=\"bbCode tagUrl\" ref=\"nofollow\" href=\"{}\">{}",
-                url.as_str(),
-                contents
-            ),
+            Some(url) => {
+                let sanitized_url = SafeHtml::sanitize(url.as_str());
+                let empty = SafeHtml::with_capacity(sanitized_url.len() + sanitized.len() + 64);
+                empty
+                    + "<a class=\"bbCode tagUrl\" ref=\"nofollow\" href=\""
+                    + &sanitized_url
+                    + "\">"
+                    + &sanitized
+            }
             // If we have no content, we are broken.
             None => {
                 el.set_broken();
-                contents
+                sanitized
             }
         }
     }

--- a/src/bbcode/tag/font.rs
+++ b/src/bbcode/tag/font.rs
@@ -1,4 +1,4 @@
-use super::Element;
+use super::{Element, SafeHtml};
 use nom::{
     bytes::complete::{tag, take_while_m_n},
     character::complete::alpha1,
@@ -8,13 +8,15 @@ use nom::{
 use std::cell::RefMut;
 
 impl super::Tag {
-    pub fn open_color_tag(el: RefMut<Element>) -> String {
+    pub fn open_color_tag(el: RefMut<Element>) -> SafeHtml {
         if let Some(arg) = el.get_argument() {
             if let Ok((_, color)) = color_from(arg) {
-                return format!(
-                    "<span class=\"bbCode tagColor\" style=\"color: {}\">",
-                    color
-                );
+                let sanitized_color = SafeHtml::sanitize(color);
+                let empty = SafeHtml::with_capacity(64 + sanitized_color.len());
+                return empty
+                    + "<span class=\"bbCode tagColor\" style=\"color: "
+                    + &sanitized_color
+                    + "\">";
             }
         }
 

--- a/src/bbcode/tag/mod.rs
+++ b/src/bbcode/tag/mod.rs
@@ -3,7 +3,7 @@ extern crate nom;
 mod embed;
 mod font;
 
-use super::Element;
+use super::{Element, SafeHtml};
 use std::{borrow::BorrowMut, cell::RefMut};
 
 pub enum Tag {
@@ -48,23 +48,23 @@ impl Tag {
     }
 
     /// Sets el to broken, returns [tagname].
-    pub fn open_broken_tag(mut el: RefMut<Element>) -> String {
+    pub fn open_broken_tag(mut el: RefMut<Element>) -> SafeHtml {
         el.borrow_mut().set_broken();
         el.to_open_str()
     }
 
     /// Returns <tagname>
-    pub fn open_simple_tag(tag: &str) -> String {
-        format!("<{}>", &tag)
+    pub fn open_simple_tag(tag: &'static str) -> SafeHtml {
+        SafeHtml::with_capacity(16) + "<" + tag + ">"
     }
 
     /// Returns </tagname>
-    pub fn close_simple_tag(tag: &str) -> String {
-        format!("</{}>", &tag)
+    pub fn close_simple_tag(tag: &'static str) -> SafeHtml {
+        SafeHtml::with_capacity(16) + "</" + tag + ">"
     }
 
     /// Returns <tagname />
-    pub fn self_closing_tag(tag: &str) -> String {
-        format!("<{} />", &tag)
+    pub fn self_closing_tag(tag: &'static str) -> SafeHtml {
+        SafeHtml::with_capacity(16) + "<" + tag + " />"
     }
 }

--- a/src/web/chat/server.rs
+++ b/src/web/chat/server.rs
@@ -1,7 +1,7 @@
 use super::implement::{self, UserActivity};
 use super::implement::{ChatLayer, Connection};
 use super::message::{self, SanitaryPost, SanitaryPosts};
-use crate::bbcode::{tokenize, Constructor, Parser, Smilies};
+use crate::bbcode::{sanitize, tokenize, Constructor, Parser, Smilies};
 use actix::prelude::*;
 use rand::{self, rngs::ThreadRng, Rng};
 use std::collections::{HashMap, HashSet};
@@ -128,8 +128,8 @@ impl ChatServer {
             message_id: message.message_id,
             message_date: message.message_date,
             message_edit_date: message.message_edit_date,
-            message: self.constructor.build(ast),
-            message_raw: Constructor::sanitize(&message.message),
+            message: self.constructor.build(ast).take(),
+            message_raw: sanitize(&message.message),
         }
     }
 


### PR DESCRIPTION
Replaces pull request https://github.com/jaw-sh/ruforo/pull/6. That fix was a band aid, so I looked into a way to make this more robust. Hence this new pull request.

Use the type system to help avoid XSS/script injection vulnerabilities. Introduces a new `SafeHtml` type string can only be constructed from:
- a string which has been sanitized (i.e. <>&"' characters replaced with HTML entities)
- a literal string, enforced by the 'static lifetime annotation
- concatenations of already constructed `SafeHtml` strings

A `SafeHtml` string cannot be constructed from unsanitized user input, and this is enforced by the type system. This is not a complete guarantee of safety against injection. You could specify "<script>" as a string literal and it would be considered safe. But this makes the code easier to audit.